### PR TITLE
Fix Gemini API key handling in Vite app

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ View your app in AI Studio: https://ai.studio/apps/drive/1x2YAwapicOdwQmvWGxOffn
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Set the `VITE_GEMINI_API_KEY` in [.env.local](.env.local) (or your shell) to your Gemini API key. The `VITE_` prefix is required so Vite exposes the value to the client bundle.
 3. Run the app:
    `npm run dev`
+
+## Deploying to Vercel
+
+- Add `VITE_GEMINI_API_KEY` to your project's **Build & Runtime Environment Variables** in the Vercel dashboard so the key is available when Vite builds the production bundle.
+- Never commit your API key to the repository. Use the environment variable configuration instead.

--- a/index.tsx
+++ b/index.tsx
@@ -3,6 +3,14 @@ import React, { useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { GoogleGenAI, Modality } from '@google/genai';
 
+const getGenAIClient = () => {
+  const apiKey = import.meta.env.VITE_GEMINI_API_KEY as string | undefined;
+  if (!apiKey) {
+    throw new Error('Missing VITE_GEMINI_API_KEY environment variable. Please configure your Gemini API key.');
+  }
+  return new GoogleGenAI({ apiKey });
+};
+
 const ImagePreviewModal = ({ imageHistory, initialIndex, onClose, onDownload }) => {
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
 
@@ -132,8 +140,6 @@ const App = () => {
   - **Overall Feel:** Product-centric, data-driven, clean, and user-friendly.
   `;
 
-  const ai = new GoogleGenAI({ apiKey: process.env.API_KEY as string });
-
   const generateInitialImages = async () => {
     if (!blogContent.trim()) {
       setError('Please paste your blog content first.');
@@ -145,6 +151,7 @@ const App = () => {
     setCurrentVersions({});
 
     try {
+        const ai = getGenAIClient();
         const basePrompt = `${STYLE_PROMPT} Based on the following blog content, generate images for a tech blog. Blog Content: "${blogContent}"`;
         
         const groupedByAspectRatio = imageConfigs.reduce((acc, config) => {
@@ -204,6 +211,7 @@ const App = () => {
     const aspectRatio = findClosestSupportedRatio(config.width, config.height);
 
     try {
+        const ai = getGenAIClient();
         let newImageSrc: string | null = null;
         
         if (selectedModel === 'gemini-2.5-flash-image-preview') {
@@ -278,6 +286,7 @@ const App = () => {
     const aspectRatio = findClosestSupportedRatio(config.width, config.height);
 
     try {
+        const ai = getGenAIClient();
         const prompt = `${STYLE_PROMPT} Based on the following blog content, generate an image for a tech blog. Blog Content: "${blogContent}"`;
         
         const response = await ai.models.generateImages({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,10 @@
     },
     "allowImportingTsExtensions": true,
     "noEmit": true
-  }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "vite-env.d.ts"
+  ]
 }

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_GEMINI_API_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,17 +1,10 @@
 import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 
-export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, '.', '');
-    return {
-      define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
-      },
-      resolve: {
-        alias: {
-          '@': path.resolve(__dirname, '.'),
-        }
-      }
-    };
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- read the Gemini API key from `import.meta.env.VITE_GEMINI_API_KEY` so deployments receive runtime credentials
- update build tooling and typings to support the new client environment variable
- document the required `VITE_GEMINI_API_KEY` configuration locally and on Vercel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7aada9320833186bfc87685e55208