### PR TITLE
Reference public favicon and OG images

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,20 +2,28 @@
 <html>
   <head>
     <title>Zuddl Blog Thumbnail Generator</title>
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <meta property="og:title" content="Zuddl Blog Thumbnail Generator">
+    <meta property="og:description" content="Experimental app for Zuddl's blog thumbnail generation.">
+    <meta property="og:image" content="/og-image.png">
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:title" content="Zuddl Blog Thumbnail Generator">
+    <meta property="twitter:description" content="Experimental app for Zuddl's blog thumbnail generation.">
+    <meta property="twitter:image" content="/og-image.png">
     <link rel="stylesheet" href="index.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <script type="importmap">
-{
-  "imports": {
-    "@google/genai": "https://aistudiocdn.com/@google/genai@^1.19.0",
-    "react/": "https://aistudiocdn.com/react@^19.1.1/",
-    "react": "https://aistudiocdn.com/react@^19.1.1",
-    "react-dom/": "https://aistudiocdn.com/react-dom@^19.1.1/"
-  }
-}
-</script>
+    <script type="importmap">
+      {
+        "imports": {
+          "@google/genai": "https://aistudiocdn.com/@google/genai@^1.19.0",
+          "react/": "https://aistudiocdn.com/react@^19.1.1/",
+          "react": "https://aistudiocdn.com/react@^19.1.1",
+          "react-dom/": "https://aistudiocdn.com/react-dom@^19.1.1/"
+        }
+      }
+    </script>
 </head>
   <body>
     <div id="root"></div>

--- a/public/README.md
+++ b/public/README.md
@@ -1,0 +1,3 @@
+# Public Assets
+
+Place OG images, favicons, and other public-facing assets in this directory.


### PR DESCRIPTION
## Summary
- link the deployed app to the favicon stored in the public directory
- expose the uploaded OG image via Open Graph and Twitter metadata
- tidy the import map formatting for readability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7d4ec01908331b593e5778d547fcd