### PR TITLE
Fix favicon and OG image references

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,14 +2,14 @@
 <html>
   <head>
     <title>Zuddl Blog Thumbnail Generator</title>
-    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="icon" type="image/png" href="/Favicon.png">
     <meta property="og:title" content="Zuddl Blog Thumbnail Generator">
     <meta property="og:description" content="Experimental app for Zuddl's blog thumbnail generation.">
-    <meta property="og:image" content="/og-image.png">
+    <meta property="og:image" content="/OG_image.png">
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:title" content="Zuddl Blog Thumbnail Generator">
     <meta property="twitter:description" content="Experimental app for Zuddl's blog thumbnail generation.">
-    <meta property="twitter:image" content="/og-image.png">
+    <meta property="twitter:image" content="/OG_image.png">
     <link rel="stylesheet" href="index.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- update the favicon link to use the existing PNG in the public directory
- point Open Graph and Twitter image metadata to the provided OG image asset

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7e49eebb88331abf5eb0e74d93fb6