### PR TITLE
Improve Gemini API key guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ View your app in AI Studio: https://ai.studio/apps/drive/1x2YAwapicOdwQmvWGxOffn
 
 ## Deploying to Vercel
 
-- Add `VITE_GEMINI_API_KEY` to your project's **Build & Runtime Environment Variables** in the Vercel dashboard so the key is available when Vite builds the production bundle.
+- Add `VITE_GEMINI_API_KEY` to your project's **Build & Runtime Environment Variables** in the Vercel dashboard so the key is available when Vite builds the production bundle. After updating the variable, trigger a fresh deployment so the new value is embedded in the statically generated client bundle.
 - Never commit your API key to the repository. Use the environment variable configuration instead.

--- a/index.tsx
+++ b/index.tsx
@@ -4,10 +4,17 @@ import { createRoot } from 'react-dom/client';
 import { GoogleGenAI, Modality } from '@google/genai';
 
 const getGenAIClient = () => {
-  const apiKey = import.meta.env.VITE_GEMINI_API_KEY as string | undefined;
+  const rawApiKey = import.meta.env.VITE_GEMINI_API_KEY as string | undefined;
+  const apiKey = typeof rawApiKey === 'string' ? rawApiKey.trim() : undefined;
+
   if (!apiKey) {
-    throw new Error('Missing VITE_GEMINI_API_KEY environment variable. Please configure your Gemini API key.');
+    const deploymentHint = import.meta.env.DEV
+      ? 'Set VITE_GEMINI_API_KEY in your local .env.local file.'
+      : 'Double-check the Vercel Environment Variables dashboard, ensure VITE_GEMINI_API_KEY is set, and trigger a redeploy so the value is baked into the build.';
+
+    throw new Error(`Missing VITE_GEMINI_API_KEY environment variable. ${deploymentHint}`);
   }
+
   return new GoogleGenAI({ apiKey });
 };
 


### PR DESCRIPTION
## Summary
- trim the Gemini API key before constructing the client and expand the runtime error with deployment troubleshooting hints
- update the Vercel deployment instructions to remind maintainers to redeploy after editing environment variables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7f9ecfd7c83319e4e7fb15441a275