### PR TITLE
Add Hugging Face provider and serverless proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ View your app in AI Studio: https://ai.studio/apps/drive/1x2YAwapicOdwQmvWGxOffn
 1. Install dependencies:
    `npm install`
 2. Set the `VITE_GEMINI_API_KEY` in [.env.local](.env.local) (or your shell) to your Gemini API key. The `VITE_` prefix is required so Vite exposes the value to the client bundle.
-3. Run the app:
+3. Set the `HF_KEY` environment variable for the serverless Hugging Face proxy (for example in your shell before running `npm run dev`, or by adding it to `.env.local` if you are using a dev server that forwards API routes).
+4. Run the app:
    `npm run dev`
 
 ## Deploying to Vercel
 
 - Add `VITE_GEMINI_API_KEY` to your project's **Build & Runtime Environment Variables** in the Vercel dashboard so the key is available when Vite builds the production bundle.
+- Add `HF_KEY` to the Runtime Environment Variables so the Hugging Face API proxy can authenticate requests. This key remains on the server.
 - Never commit your API key to the repository. Use the environment variable configuration instead.

--- a/api/hugging-face.ts
+++ b/api/hugging-face.ts
@@ -1,0 +1,119 @@
+const HF_API_BASE = 'https://api-inference.huggingface.co/models/';
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 1000;
+
+interface HuggingFaceRequestBody {
+  prompt?: unknown;
+  model?: unknown;
+}
+
+const parseBody = (body: any): HuggingFaceRequestBody => {
+  if (!body) return {};
+  if (typeof body === 'object') return body;
+  try {
+    return JSON.parse(body);
+  } catch {
+    return {};
+  }
+};
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+export default async function handler(req: any, res: any) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  const body = parseBody(req.body);
+  const prompt = typeof body.prompt === 'string' ? body.prompt : '';
+  const model = typeof body.model === 'string' && body.model.trim() ? body.model.trim() : 'stabilityai/sd-turbo';
+
+  if (!prompt.trim()) {
+    res.status(400).json({ error: 'Prompt is required.' });
+    return;
+  }
+
+  const apiKey = process.env.HF_KEY;
+  if (!apiKey) {
+    res.status(500).json({ error: 'Hugging Face API key is not configured.' });
+    return;
+  }
+
+  const url = `${HF_API_BASE}${encodeURIComponent(model)}`;
+
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+          'Accept': '*/*',
+        },
+        body: JSON.stringify({ inputs: prompt }),
+      });
+
+      if (response.status === 503) {
+        let errorPayload: any = null;
+        try {
+          errorPayload = await response.json();
+        } catch {
+          // ignore parsing errors for retry logic
+        }
+
+        const isLoading = typeof errorPayload?.error === 'string' && errorPayload.error.toLowerCase().includes('loading');
+        if (isLoading && attempt < MAX_RETRIES - 1) {
+          await delay(RETRY_DELAY_MS);
+          continue;
+        }
+
+        res.status(503).json({ error: errorPayload?.error || 'The Hugging Face model is unavailable. Please try again later.' });
+        return;
+      }
+
+      if (!response.ok) {
+        let errorMessage = 'Hugging Face request failed.';
+        try {
+          const errorData = await response.json();
+          if (typeof errorData?.error === 'string') {
+            errorMessage = errorData.error;
+          } else if (typeof errorData?.message === 'string') {
+            errorMessage = errorData.message;
+          }
+        } catch {
+          const fallbackText = await response.text();
+          if (fallbackText) {
+            errorMessage = fallbackText;
+          }
+        }
+
+        res.status(response.status).json({ error: errorMessage });
+        return;
+      }
+
+      const contentType = response.headers.get('content-type') || '';
+      if (contentType.includes('application/json')) {
+        const data = await response.json();
+        res.setHeader('Content-Type', 'application/json');
+        res.status(200).json({ type: 'text', data });
+        return;
+      }
+
+      const arrayBuffer = await response.arrayBuffer();
+      const buffer = Buffer.from(arrayBuffer);
+      const mimeType = contentType || 'image/png';
+
+      res.setHeader('Content-Type', mimeType);
+      res.status(200).send(buffer);
+      return;
+    } catch (error: any) {
+      if (attempt === MAX_RETRIES - 1) {
+        res.status(500).json({ error: error?.message || 'Unexpected error while contacting Hugging Face.' });
+        return;
+      }
+      await delay(RETRY_DELAY_MS);
+    }
+  }
+}

--- a/index.css
+++ b/index.css
@@ -82,6 +82,13 @@ h1 {
   gap: var(--spacing-s);
 }
 
+.provider-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-l);
+  align-items: flex-end;
+}
+
 .model-selector-wrapper label {
   font-weight: 600;
   font-size: 1rem;
@@ -119,6 +126,28 @@ h1 {
   background-repeat: no-repeat;
   background-position: center;
   pointer-events: none;
+}
+
+.model-input {
+  padding: 12px 16px;
+  border-radius: var(--btn-border-radius);
+  border: 1px solid var(--border-color);
+  font-family: var(--font-family);
+  font-size: 1rem;
+  background-color: var(--card-background-color);
+  color: var(--text-color);
+  width: min(320px, 100%);
+  box-sizing: border-box;
+}
+
+.model-input:focus {
+  outline: none;
+  border-color: var(--primary-color);
+}
+
+.model-helper-text {
+  font-size: 0.8rem;
+  color: #6c757d;
 }
 
 
@@ -390,6 +419,34 @@ h1 {
   padding: var(--spacing-m);
   border-radius: var(--card-border-radius);
   text-align: center;
+}
+
+.text-output-card {
+  background-color: var(--card-background-color);
+  box-shadow: var(--card-shadow);
+  border-radius: var(--card-border-radius);
+  padding: var(--spacing-m);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-m);
+}
+
+.text-output-card h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.text-output-card pre {
+  margin: 0;
+  padding: var(--spacing-m);
+  background-color: #f8f5ff;
+  border-radius: var(--card-border-radius);
+  border: 1px solid var(--border-color);
+  font-family: 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 260px;
+  overflow: auto;
 }
 
 .add-image-btn {

--- a/index.tsx
+++ b/index.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { GoogleGenAI, Modality } from '@google/genai';
 
@@ -9,6 +9,50 @@ const getGenAIClient = () => {
     throw new Error('Missing VITE_GEMINI_API_KEY environment variable. Please configure your Gemini API key.');
   }
   return new GoogleGenAI({ apiKey });
+};
+
+type ProviderOption = 'google' | 'hugging-face';
+
+const arrayBufferToDataUrl = (buffer: ArrayBuffer, mimeType: string) => {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return `data:${mimeType};base64,${btoa(binary)}`;
+};
+
+const extractTextFromHFResponse = (data: unknown): string => {
+  if (typeof data === 'string') {
+    return data;
+  }
+
+  if (Array.isArray(data)) {
+    const texts = data
+      .map((item) => {
+        if (typeof item === 'string') return item;
+        if (item && typeof item === 'object') {
+          if (typeof (item as any).generated_text === 'string') return (item as any).generated_text;
+          if (typeof (item as any).text === 'string') return (item as any).text;
+        }
+        return JSON.stringify(item, null, 2);
+      })
+      .filter(Boolean);
+    return texts.join('\n\n');
+  }
+
+  if (data && typeof data === 'object') {
+    const maybeText = (data as any).generated_text || (data as any).text;
+    if (typeof maybeText === 'string') {
+      return maybeText;
+    }
+  }
+
+  try {
+    return JSON.stringify(data, null, 2);
+  } catch {
+    return 'Received an unsupported response format from Hugging Face.';
+  }
 };
 
 const ImagePreviewModal = ({ imageHistory, initialIndex, onClose, onDownload }) => {
@@ -102,7 +146,10 @@ const App = () => {
   const [loading, setLoading] = useState(false);
   const [regenerating, setRegenerating] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [selectedProvider, setSelectedProvider] = useState<ProviderOption>('google');
   const [selectedModel, setSelectedModel] = useState('imagen-4.0-generate-001');
+  const [huggingFaceModel, setHuggingFaceModel] = useState('stabilityai/sd-turbo');
+  const [huggingFaceOutput, setHuggingFaceOutput] = useState<string | null>(null);
   const [modalState, setModalState] = useState<{ key: string; history: string[]; index: number } | null>(null);
   
   const initialImageConfigs: ImageConfig[] = [
@@ -140,6 +187,54 @@ const App = () => {
   - **Overall Feel:** Product-centric, data-driven, clean, and user-friendly.
   `;
 
+  useEffect(() => {
+    if (selectedProvider === 'google') {
+      setHuggingFaceOutput(null);
+    }
+  }, [selectedProvider]);
+
+  const callHuggingFace = async (prompt: string) => {
+    const response = await fetch('/api/hugging-face', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt, model: huggingFaceModel }),
+    });
+
+    const contentType = response.headers.get('content-type') || '';
+
+    if (!response.ok) {
+      let message = 'Failed to contact Hugging Face.';
+      if (contentType.includes('application/json')) {
+        try {
+          const errorData = await response.json();
+          if (typeof errorData?.error === 'string') {
+            message = errorData.error;
+          }
+        } catch {
+          // ignore JSON parsing issues for error responses
+        }
+      } else {
+        const text = await response.text();
+        if (text) {
+          message = text;
+        }
+      }
+      throw new Error(message);
+    }
+
+    if (contentType.includes('application/json')) {
+      const data = await response.json();
+      if (data?.type === 'text') {
+        return { kind: 'text', payload: extractTextFromHFResponse(data.data) } as const;
+      }
+      return { kind: 'text', payload: extractTextFromHFResponse(data) } as const;
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    const mimeType = contentType || 'image/png';
+    return { kind: 'image', payload: arrayBufferToDataUrl(arrayBuffer, mimeType) } as const;
+  };
+
   const generateInitialImages = async () => {
     if (!blogContent.trim()) {
       setError('Please paste your blog content first.');
@@ -151,9 +246,10 @@ const App = () => {
     setCurrentVersions({});
 
     try {
+      if (selectedProvider === 'google') {
         const ai = getGenAIClient();
         const basePrompt = `${STYLE_PROMPT} Based on the following blog content, generate images for a tech blog. Blog Content: "${blogContent}"`;
-        
+
         const groupedByAspectRatio = imageConfigs.reduce((acc, config) => {
             const ratio = findClosestSupportedRatio(config.width, config.height);
             if (!acc[ratio]) acc[ratio] = [];
@@ -176,7 +272,7 @@ const App = () => {
                 });
             });
         }
-        
+
         const newImages: Record<string, string[]> = {};
         allGeneratedImages.forEach(({ key, src }) => newImages[key] = [src]);
         setImages(newImages);
@@ -184,6 +280,35 @@ const App = () => {
         const initialVersions: Record<string, number> = {};
         Object.keys(newImages).forEach(key => initialVersions[key] = 0);
         setCurrentVersions(initialVersions);
+        setHuggingFaceOutput(null);
+      } else {
+        const basePrompt = `${STYLE_PROMPT} Based on the following blog content, generate images for a tech blog. Blog Content: "${blogContent}"`;
+        const results: { key: string; label: string; kind: 'image' | 'text'; value: string }[] = [];
+
+        for (const config of imageConfigs) {
+          const ratio = findClosestSupportedRatio(config.width, config.height);
+          const prompt = `${basePrompt} The required aspect ratio is ${ratio} with a resolution close to ${config.width}x${config.height}.`;
+          const result = await callHuggingFace(prompt);
+          results.push({ key: config.key, label: config.title, kind: result.kind, value: result.payload });
+        }
+
+        const newImages: Record<string, string[]> = {};
+        const textSnippets: string[] = [];
+
+        results.forEach(({ key, label, kind, value }) => {
+          if (kind === 'image') {
+            newImages[key] = [value];
+          } else {
+            textSnippets.push(`${label}:\n${value}`);
+          }
+        });
+
+        setImages(newImages);
+        const initialVersions: Record<string, number> = {};
+        Object.keys(newImages).forEach(key => initialVersions[key] = 0);
+        setCurrentVersions(initialVersions);
+        setHuggingFaceOutput(textSnippets.length ? textSnippets.join('\n\n') : null);
+      }
 
     } catch (err) {
       console.error(err);
@@ -211,9 +336,10 @@ const App = () => {
     const aspectRatio = findClosestSupportedRatio(config.width, config.height);
 
     try {
+      if (selectedProvider === 'google') {
         const ai = getGenAIClient();
         let newImageSrc: string | null = null;
-        
+
         if (selectedModel === 'gemini-2.5-flash-image-preview') {
             const currentImageHistory = images[imageKey];
             const currentImageIndex = currentVersions[imageKey];
@@ -222,16 +348,16 @@ const App = () => {
             }
             const currentImageSrc = currentImageHistory[currentImageIndex];
             const base64Data = currentImageSrc.split(',')[1];
-            
+
             const imagePart = { inlineData: { data: base64Data, mimeType: 'image/png' } };
             const textPart = { text: modificationPrompt };
-            
+
             const response = await ai.models.generateContent({
                 model: 'gemini-2.5-flash-image-preview',
                 contents: { parts: [imagePart, textPart] },
                 config: { responseModalities: [Modality.IMAGE, Modality.TEXT] },
             });
-            
+
             const imagePartResponse = response.candidates?.[0]?.content?.parts?.find(part => part.inlineData);
             if (imagePartResponse?.inlineData) {
                 newImageSrc = `data:image/png;base64,${imagePartResponse.inlineData.data}`;
@@ -244,13 +370,13 @@ const App = () => {
             Original Blog Content: "${blogContent}"
             Modification Request: "${modificationPrompt}"
             The required aspect ratio is ${aspectRatio}.`;
-            
+
             const response = await ai.models.generateImages({
                 model: selectedModel, prompt, config: { numberOfImages: 1, outputMimeType: 'image/png', aspectRatio },
             });
             newImageSrc = `data:image/png;base64,${response.generatedImages[0].image.imageBytes}`;
         }
-        
+
         if (newImageSrc) {
             setImages(prev => {
                 const history = prev[imageKey] || [];
@@ -260,6 +386,30 @@ const App = () => {
             });
             setCurrentVersions(prev => ({...prev, [imageKey]: (prev[imageKey] ?? -1) + 1}));
         }
+      } else {
+        const prompt = `${STYLE_PROMPT} Regenerate an image for a tech blog based on the original content and a modification request.
+        Original Blog Content: "${blogContent}"
+        Modification Request: "${modificationPrompt}"
+        The required aspect ratio is ${aspectRatio}.`;
+
+        const result = await callHuggingFace(prompt);
+
+        if (result.kind === 'image') {
+          setImages(prev => {
+              const history = prev[imageKey] || [];
+              const newHistory = history.slice(0, (currentVersions[imageKey] ?? 0) + 1);
+              return { ...prev, [imageKey]: [...newHistory, result.payload] };
+          });
+          setCurrentVersions(prev => ({...prev, [imageKey]: (prev[imageKey] ?? -1) + 1}));
+          setHuggingFaceOutput(null);
+        } else {
+          const label = config?.title || imageKey;
+          setHuggingFaceOutput(prev => {
+            const content = `${label} response:\n${result.payload}`;
+            return prev ? `${content}\n\n${prev}` : content;
+          });
+        }
+      }
 
     } catch (err) {
         console.error(err);
@@ -286,9 +436,10 @@ const App = () => {
     const aspectRatio = findClosestSupportedRatio(config.width, config.height);
 
     try {
+      if (selectedProvider === 'google') {
         const ai = getGenAIClient();
         const prompt = `${STYLE_PROMPT} Based on the following blog content, generate an image for a tech blog. Blog Content: "${blogContent}"`;
-        
+
         const response = await ai.models.generateImages({
             model: 'imagen-4.0-generate-001',
             prompt,
@@ -302,9 +453,29 @@ const App = () => {
                 [imageKey]: [newImageSrc]
             }));
             setCurrentVersions(prev => ({...prev, [imageKey]: 0}));
+            setHuggingFaceOutput(null);
         } else {
             throw new Error("Image generation failed to return an image.");
         }
+      } else {
+        const prompt = `${STYLE_PROMPT} Based on the following blog content, generate an image for a tech blog. Blog Content: "${blogContent}". Maintain an aspect ratio close to ${aspectRatio} (${config.width}x${config.height}).`;
+        const result = await callHuggingFace(prompt);
+
+        if (result.kind === 'image') {
+          setImages(prev => ({
+              ...prev,
+              [imageKey]: [result.payload]
+          }));
+          setCurrentVersions(prev => ({...prev, [imageKey]: 0}));
+          setHuggingFaceOutput(null);
+        } else {
+          const label = config?.title || imageKey;
+          setHuggingFaceOutput(prev => {
+            const content = `${label} response:\n${result.payload}`;
+            return prev ? `${content}\n\n${prev}` : content;
+          });
+        }
+      }
 
     } catch (err) {
         console.error(err);
@@ -399,20 +570,54 @@ const App = () => {
       )}
       <h1>Zuddl Blog Thumbnail Generator</h1>
       <div className="main-controls">
-        <div className="model-selector-wrapper">
-            <label htmlFor="model-selector">Regeneration Model</label>
-            <div className="select-container">
-              <select 
-                  id="model-selector" 
-                  className="model-selector"
-                  value={selectedModel} 
-                  onChange={e => setSelectedModel(e.target.value)}
-                  disabled={loading || !!regenerating}
-              >
-                  <option value="imagen-4.0-generate-001">Imagen 4.0 (Generate)</option>
-                  <option value="gemini-2.5-flash-image-preview">Gemini 2.5 Flash (Edit)</option>
-              </select>
+        <div className="provider-row">
+          <div className="model-selector-wrapper">
+              <label htmlFor="provider-selector">AI Provider</label>
+              <div className="select-container">
+                <select
+                    id="provider-selector"
+                    className="model-selector"
+                    value={selectedProvider}
+                    onChange={e => setSelectedProvider(e.target.value as ProviderOption)}
+                    disabled={loading || !!regenerating}
+                >
+                    <option value="google">Google Gemini</option>
+                    <option value="hugging-face">Hugging Face</option>
+                </select>
+              </div>
+          </div>
+          {selectedProvider === 'google' ? (
+            <div className="model-selector-wrapper">
+              <label htmlFor="model-selector">Regeneration Model</label>
+              <div className="select-container">
+                <select
+                    id="model-selector"
+                    className="model-selector"
+                    value={selectedModel}
+                    onChange={e => setSelectedModel(e.target.value)}
+                    disabled={loading || !!regenerating}
+                >
+                    <option value="imagen-4.0-generate-001">Imagen 4.0 (Generate)</option>
+                    <option value="gemini-2.5-flash-image-preview">Gemini 2.5 Flash (Edit)</option>
+                </select>
+              </div>
             </div>
+          ) : (
+            <div className="model-selector-wrapper">
+              <label htmlFor="hf-model-input">Hugging Face Model</label>
+              <input
+                id="hf-model-input"
+                type="text"
+                className="model-input"
+                value={huggingFaceModel}
+                onChange={e => setHuggingFaceModel(e.target.value)}
+                disabled={loading || !!regenerating}
+                placeholder="stabilityai/sd-turbo"
+                aria-label="Hugging Face model name"
+              />
+              <span className="model-helper-text">Defaults to stabilityai/sd-turbo</span>
+            </div>
+          )}
         </div>
         <textarea
           className="blog-input"
@@ -425,6 +630,12 @@ const App = () => {
           {loading ? <><div className="spinner"></div><span>Generating...</span></> : 'Generate Thumbnails'}
         </button>
       </div>
+      {huggingFaceOutput && (
+        <div className="text-output-card" role="status">
+          <h2>Hugging Face Response</h2>
+          <pre>{huggingFaceOutput}</pre>
+        </div>
+      )}
       {error && <p className="error-message" role="alert">{error}</p>}
       <div className="image-grid">
         {imageConfigs.map(({ key, title, width, height, aspectClass, isRemovable }) => {


### PR DESCRIPTION
## Summary
- add a serverless Hugging Face inference proxy with retries for model warmups
- update the app to route Hugging Face requests through the proxy and show text or image responses in the UI
- adjust styling and docs to cover the new provider configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d81ddda240833184c750d3bb8094f4